### PR TITLE
Fix dockerfile: replace `;` by `&&`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@
 
 FROM ubuntu:16.04 AS build-simulator-core
 
-RUN echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections; \
-    echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections;
+RUN echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections \
+    && echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections
 
 RUN apt-get -y update && apt-get install -y \
     genisoimage \
@@ -40,22 +40,17 @@ RUN apt-get -y update && apt-get install -y \
     mysql-server \
     openssh-client \
     && apt-get clean all \
-    && rm -rf /var/lib/apt/lists/*;
+    && rm -rf /var/lib/apt/lists/*
 
-# TODO: check if and why this is needed
-RUN mkdir -p /root/.ssh \
-    && chmod 0700 /root/.ssh \
-    && ssh-keygen -t rsa -N "" -f id_rsa.cloud
+RUN mkdir -p /var/run/mysqld \
+    && chown mysql /var/run/mysqld \
+    && echo '''sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"''' >> /etc/mysql/mysql.conf.d/mysqld.cnf
 
-RUN mkdir -p /var/run/mysqld; \
-    chown mysql /var/run/mysqld; \
-    echo '''sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"''' >> /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN find /var/lib/mysql -type f -exec touch {} \; && (/usr/bin/mysqld_safe &) && sleep 30 && mysqladmin -u root -proot password ''
 
-RUN find /var/lib/mysql -type f -exec touch {} \; && (/usr/bin/mysqld_safe &); sleep 30; mysqladmin -u root -proot password ''
-
-RUN wget https://github.com/apache/cloudstack/archive/4.11.2.0.tar.gz -O /opt/cloudstack.tar.gz; \
-    mkdir -p /opt/cloudstack; \
-    tar xvzf /opt/cloudstack.tar.gz -C /opt/cloudstack --strip-components=1
+RUN wget https://github.com/apache/cloudstack/archive/4.11.2.0.tar.gz -O /opt/cloudstack.tar.gz \
+    && mkdir -p /opt/cloudstack \
+    && tar xvzf /opt/cloudstack.tar.gz -C /opt/cloudstack --strip-components=1
 
 WORKDIR /opt/cloudstack
 
@@ -63,12 +58,12 @@ RUN mvn -Pdeveloper -Dsimulator -DskipTests clean install
 RUN mvn -Pdeveloper -Dsimulator dependency:go-offline
 RUN mvn -pl client jetty:run -Dsimulator -Djetty.skip -Dorg.eclipse.jetty.annotations.maxWait=120
 
-RUN (/usr/bin/mysqld_safe &); \
-    sleep 5; \
-    mvn -Pdeveloper -pl developer -Ddeploydb; \
-    mvn -Pdeveloper -pl developer -Ddeploydb-simulator; \
-    MARVIN_FILE=$(find /opt/cloudstack/tools/marvin/dist/ -name "Marvin*.tar.gz"); \
-    pip install $MARVIN_FILE;
+RUN (/usr/bin/mysqld_safe &) \
+    && sleep 5 \
+    && mvn -Pdeveloper -pl developer -Ddeploydb \
+    && mvn -Pdeveloper -pl developer -Ddeploydb-simulator \
+    && MARVIN_FILE=$(find /opt/cloudstack/tools/marvin/dist/ -name "Marvin*.tar.gz") \
+    && pip install $MARVIN_FILE
 
 COPY zones.cfg /opt/zones.cfg
 COPY nginx_default.conf /etc/nginx/sites-available/default


### PR DESCRIPTION
Symbols `;` are replaced by `&&` to fail build if some instruction is failed